### PR TITLE
Fix PHP 8: Implicitly marking parameter $whenOverlapping as nullable is deprecat…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ or add the package to your `composer.json`
 }
 ```
 
-Scheduler V3 requires php >= 7.1, please use the [v2 branch](https://github.com/peppeocchi/php-cron-scheduler/tree/v2.x) for php versions < 7.1.
+Scheduler V3 requires php >= 7.2, please use the [v2 branch](https://github.com/peppeocchi/php-cron-scheduler/tree/v2.x) for php versions <= 7.1.
 
 ## How it works
 

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.1",
-        "dragonmantank/cron-expression": "^2.3"
+        "php": ">=7.2",
+        "dragonmantank/cron-expression": "^3.4"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.7",

--- a/src/GO/Job.php
+++ b/src/GO/Job.php
@@ -254,10 +254,10 @@ class Job
      * The job id is used as a filename for the lock file.
      *
      * @param  string    $tempDir          The directory path for the lock files
-     * @param  callable  $whenOverlapping  A callback to ignore job overlapping
+     * @param  ?callable  $whenOverlapping  A callback to ignore job overlapping
      * @return self
      */
-    public function onlyOne($tempDir = null, callable $whenOverlapping = null)
+    public function onlyOne($tempDir = null, ?callable $whenOverlapping = null)
     {
         if ($tempDir === null || ! is_dir($tempDir)) {
             $tempDir = $this->tempDir;


### PR DESCRIPTION
Fix: Implicitly marking parameter $whenOverlapping as nullable is deprecated, the explicit nullable type must be used instead
Fix: Cron\CronExpression::factory(): Implicitly marking parameter $fieldFactory as nullable is deprecated

Drop support to PHP 7.1 to align with Cron\CronExpression on v3 branch

